### PR TITLE
Fixed Invocation Typo

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -29,7 +29,7 @@ So you want to build a plugin with Komand?  You've come to the right place!
 
 Plugins in Komand can be built currently using Python or Go.  
 
-Plugins support any number of `triggers` or `actions`.  Plugins are defined using a `plugin.spec.yaml`, and a plugin shell can be codegen'd using `komand plugin generate [python|go] <path/to/plugin.spec.yaml>`. 
+Plugins support any number of `triggers` or `actions`.  Plugins are defined using a `plugin.spec.yaml`, and a plugin shell can be codegen'd using `komand generate [python|go] <path/to/plugin.spec.yaml>`. 
 
 When writing plugins, it's recommended to work directly out of the `plugins` repository. Locate your `plugins.spec.yaml` to `plugins/plugin.spec.yaml` and generate the skeleton from there so it fits nicely with the other plugins.
 


### PR DESCRIPTION
Should be `komand generate` instead of `komand plugin generate`, based on running the app.