### PR TITLE
Update SPEC.md for accuracy

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -45,7 +45,7 @@ First, create a file called `plugin.spec.yaml` and populate it with some data:
 plugin_spec_version: v1
 name: example 
 title: Example Descriptive Title
-description: "Example plugin."
+description: "Example plugin"
 version: 0.1.0
 vendor: acmecorp 
 tags: ["example"]


### PR DESCRIPTION
Remove `.` from example plugin.spec.yaml `description` field. It did not accurately reflect the style guide.